### PR TITLE
Adds ratio to fourth column as color-coded box

### DIFF
--- a/colorcube.js
+++ b/colorcube.js
@@ -3,6 +3,31 @@ const BLACK  = tinycolor("#000000");
 const AARATIO = 4.5;
 var colorArray = [];
 
+function getRoundedRatio(color1, color2) {
+  var ratio = tinycolor.readability(color1, color2);
+      ratio = Math.round(ratio * 10) / 10;
+  return ratio;
+}
+
+function outputRatio(ratio, div) {
+  if ( ratio > (AARATIO + 0.5) ) {
+    // if it passes by more than .5, create a green div
+    ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+    // and append it
+    div.innerHTML = div.innerHTML + ratioGreen;
+  } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
+    // if it barely passes, create a yellow div
+    ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+    // and append it
+    div.innerHTML = div.innerHTML + ratioYellow;
+  } else {
+    // if it fails by more than .5, create a red div
+    ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+    // and append it
+    div.innerHTML = div.innerHTML + ratioRed;
+  }
+}
+
 var button = document.querySelector('#brand-color--button');
 button.onclick = function(e) {
   e.preventDefault();
@@ -10,91 +35,45 @@ button.onclick = function(e) {
   var stringInput = document.querySelector('#brand-color--field').value;
   // turn it into an array
   colorArray = stringInput.split("\n");
-  // for each value in the array, change the element bg-color
+  
+  // for each value in the array of user-inputted colors
+  // 1) output a div with the current color
+  // 2) output a div with that color's ratio on white
+  // 3) output a div with that color's ratio on black
+  // 4) from among colors provided, output a div with
+  //        a) the most legible bg-color to pair with the current color
+  //        b) the ratio between those two colors
   for (var i = 0; i < colorArray.length; i++) {
-    // get the first container
+    // get the first column container
     var div1 = document.getElementsByClassName('color-ratios--column color-ratios--brand-colors')[0];
-    // append a div with the corresponding background color
+    // 1) output current color
     div1.innerHTML = div1.innerHTML + '<div class="color-ratios--swatch" style="background-color: ' + colorArray[i] + '"></div>';
     
     // get the color's contrast ratio compared to white
-    var ratio = tinycolor.readability(colorArray[i], WHITE);
-        ratio = Math.round(ratio * 10) / 10;
-    
-    // get the second container
+    var ratio = getRoundedRatio(colorArray[i], WHITE);
+    // get the second column container
     var div2 = document.getElementsByClassName('color-ratios--column color-ratios--on-white')[0];
-    
-    // how readable is it?
-    if ( ratio > (AARATIO + 0.5) ) {
-      // if it passes by more than .5, create a green div
-      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
-      // and append it
-      div2.innerHTML = div2.innerHTML + ratioGreen;
-    } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
-      // if it barely passes, create a yellow div
-      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
-      // and append it
-      div2.innerHTML = div2.innerHTML + ratioYellow;
-    } else {
-      // if it fails by more than .5, create a red div
-      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
-      // and append it
-      div2.innerHTML = div2.innerHTML + ratioRed;
-    }
+    // 2) output a div with that color's ratio on white
+    outputRatio(ratio, div2);
     
     // get the color's contrast ratio compared to black
-    var ratio = tinycolor.readability(colorArray[i], BLACK);
-        ratio = Math.round(ratio * 10) / 10;
-    
-    // get the third container
+    var ratio = getRoundedRatio(colorArray[i], BLACK);
+    // get the third column container
     var div3 = document.getElementsByClassName('color-ratios--column color-ratios--on-black')[0];
-    
-    // how readable is it?
-    if ( ratio > (AARATIO + 0.5) ) {
-      // if it passes by more than .5, create a green div
-      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
-      // and append it
-      div3.innerHTML = div3.innerHTML + ratioGreen;
-    } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
-      // if it barely passes, create a yellow div
-      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
-      // and append it
-      div3.innerHTML = div3.innerHTML + ratioYellow;
-    } else {
-      // if it fails by more than .5, create a red div
-      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
-      // and append it
-      div3.innerHTML = div3.innerHTML + ratioRed;
-    }
+    // 3) output a div with that color's ratio on black
+    outputRatio(ratio, div3);
     
     // what's most readable with the current color?
     var bestPick = tinycolor.mostReadable(colorArray[i], colorArray);
-    // get the color's contrast ratio compared to white
-    var ratio = tinycolor.readability(bestPick['_originalInput'], colorArray[i]);
-        ratio = Math.round(ratio * 10) / 10;
-    
-    // get the fourth container
+    // get the color's contrast ratio compared to the best pick
+    var ratio = getRoundedRatio(colorArray[i], bestPick['_originalInput'])
+    // get the fourth column container
     var div4 = document.getElementsByClassName('color-ratios--column color-ratios--most-legible')[0];
-    
-    // append a div with the corresponding background color
+    // 4) from among colors provided, output a div with
+    //    the most legible bg-color to pair with the current color
     div4.innerHTML = div4.innerHTML + '<div class="color-ratios--swatch most-legible" style="background-color: ' + bestPick['_originalInput'] + '; color: ' + colorArray[i] + '">' + bestPick['_originalInput'] + '</div>';
-    
-    // how readable is it?
-    if ( ratio > (AARATIO + 0.5) ) {
-      // if it passes by more than .5, create a green div
-      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
-      // and append it
-      div4.innerHTML = div4.innerHTML + ratioGreen;
-    } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
-      // if it barely passes, create a yellow div
-      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
-      // and append it
-      div4.innerHTML = div4.innerHTML + ratioYellow;
-    } else {
-      // if it fails by more than .5, create a red div
-      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
-      // and append it
-      div4.innerHTML = div4.innerHTML + ratioRed;
-    }
+    // 4) from among colors provided, output a div with
+    //    the ratio between those two colors
+    outputRatio(ratio, div4);
   }
 }

--- a/colorcube.js
+++ b/colorcube.js
@@ -18,22 +18,28 @@ button.onclick = function(e) {
     div1.innerHTML = div1.innerHTML + '<div class="color-ratios--swatch" style="background-color: ' + colorArray[i] + '"></div>';
     
     // get the color's contrast ratio compared to white
-    var ratio     = tinycolor.readability(colorArray[i], WHITE);
-        ratio     = Math.round(ratio * 10) / 10;
+    var ratio = tinycolor.readability(colorArray[i], WHITE);
+        ratio = Math.round(ratio * 10) / 10;
     
     // get the second container
     var div2 = document.getElementsByClassName('color-ratios--column color-ratios--on-white')[0];
     
     // how readable is it?
     if ( ratio > (AARATIO + 0.5) ) {
-      // if it passes by more than .5, append a green div
-      div2.innerHTML = div2.innerHTML + '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+      // if it passes by more than .5, create a green div
+      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+      // and append it
+      div2.innerHTML = div2.innerHTML + ratioGreen;
     } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
-      // if it barely passes, append a yellow div
-      div2.innerHTML = div2.innerHTML + '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+      // if it barely passes, create a yellow div
+      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+      // and append it
+      div2.innerHTML = div2.innerHTML + ratioYellow;
     } else {
-      // if it fails by more than .5, append a red div
-      div2.innerHTML = div2.innerHTML + '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+      // if it fails by more than .5, create a red div
+      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+      // and append it
+      div2.innerHTML = div2.innerHTML + ratioRed;
     }
     
     // get the color's contrast ratio compared to black
@@ -45,24 +51,50 @@ button.onclick = function(e) {
     
     // how readable is it?
     if ( ratio > (AARATIO + 0.5) ) {
-      // if it passes by more than .5, append a green div
-      div3.innerHTML = div3.innerHTML + '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+      // if it passes by more than .5, create a green div
+      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+      // and append it
+      div3.innerHTML = div3.innerHTML + ratioGreen;
     } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
-      // if it barely passes, append a yellow div
-      div3.innerHTML = div3.innerHTML + '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+      // if it barely passes, create a yellow div
+      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+      // and append it
+      div3.innerHTML = div3.innerHTML + ratioYellow;
     } else {
-      // if it fails by more than .5, append a red div
-      div3.innerHTML = div3.innerHTML + '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+      // if it fails by more than .5, create a red div
+      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+      // and append it
+      div3.innerHTML = div3.innerHTML + ratioRed;
     }
     
     // what's most readable with the current color?
     var bestPick = tinycolor.mostReadable(colorArray[i], colorArray);
     // get the color's contrast ratio compared to white
-    var ratio     = tinycolor.readability(bestPick['_originalInput'], colorArray[i]);
-        ratio     = Math.round(ratio * 10) / 10;
+    var ratio = tinycolor.readability(bestPick['_originalInput'], colorArray[i]);
+        ratio = Math.round(ratio * 10) / 10;
+    
     // get the fourth container
     var div4 = document.getElementsByClassName('color-ratios--column color-ratios--most-legible')[0];
+    
     // append a div with the corresponding background color
-    div4.innerHTML = div4.innerHTML + '<div class="color-ratios--swatch most-legible" style="background-color: ' + bestPick['_originalInput'] + '; color: ' + colorArray[i] + '">' + bestPick['_originalInput'] + ' Ratio = ' + ratio + '</div>';
+    div4.innerHTML = div4.innerHTML + '<div class="color-ratios--swatch most-legible" style="background-color: ' + bestPick['_originalInput'] + '; color: ' + colorArray[i] + '">' + bestPick['_originalInput'] + '</div>';
+    
+    // how readable is it?
+    if ( ratio > (AARATIO + 0.5) ) {
+      // if it passes by more than .5, create a green div
+      ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+      // and append it
+      div4.innerHTML = div4.innerHTML + ratioGreen;
+    } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
+      // if it barely passes, create a yellow div
+      ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+      // and append it
+      div4.innerHTML = div4.innerHTML + ratioYellow;
+    } else {
+      // if it fails by more than .5, create a red div
+      ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+      // and append it
+      div4.innerHTML = div4.innerHTML + ratioRed;
+    }
   }
 }

--- a/src/scss/component/_colorcube.scss
+++ b/src/scss/component/_colorcube.scss
@@ -31,8 +31,10 @@
     width: 60px;
     
     &.most-legible {
+      float: left;
       font-weight: $font-weight-bold;
-      width: auto;
+      margin-right: 10px;
+      width: calc(100% - 70px);
     }
   }
 
@@ -47,5 +49,13 @@
   .edge {
     background-color: yellow;
     color: black;
+  }
+  
+  &--most-legible {
+    .fail,
+    .pass,
+    .edge {
+      display: inline-block;
+    }
   }
 }


### PR DESCRIPTION
Instead of including the ratio in the fourth column as just text, this inserts it as a color-coded div of its own, just like the other columns. So now, in the markup, the .pass .fail .edge divs will appear right after the corresponding .most-legible div — as a sibling, not a child.

This will then have to be styled so the ratio divs appear on the same line as the .most-legible.

Includes some refactoring.